### PR TITLE
Update NuGet package in Build.yml

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -92,7 +92,7 @@ jobs:
 
     - name: 📦 Pack Nuget package
       run: |
-        nuget pack ./OpenTelemetry.TraceListener/Module.nuspec -OutputDirectory ./output -Version ${{ needs.version.outputs.version }}
+        nuget pack ./Diagnostics.OpenTelemetry/Module.nuspec -OutputDirectory ./output -Version ${{ needs.version.outputs.version }}
       shell: pwsh
       if: github.ref == 'refs/heads/main'
 


### PR DESCRIPTION
Replaced the `nuget pack` command for `OpenTelemetry.TraceListener` with `Diagnostics.OpenTelemetry` in the `Build.yml` file. The rest of the build process, including the upload of the NuGet package, remains unchanged.